### PR TITLE
fix pre-commit / flake8 has moved to github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     -   id: python-check-blanket-noqa
     -   id: python-check-mock-methods
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: '3.8.4'  # pick a git hash / tag to point to
     hooks:
     -   id: flake8


### PR DESCRIPTION
The CI problem with python3.8 ([example](https://github.com/CuriBio/labware-domain-models/actions/runs/6881018261/job/18716488983?pr=100#step:12:29)), can be resolved by switching the flake8 repo to github.