### PR TITLE
fix problems in pre-commit

### DIFF
--- a/.github/workflows/dev-test.yaml
+++ b/.github/workflows/dev-test.yaml
@@ -22,19 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-18.04"
-          - "ubuntu-20.04"
-          - "windows-2019"
-          - "macos-10.15"
-          - "macos-11.0"
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-latest"
         python-version:
             - 3.7
             - 3.8
             - 3.9
         include:
           # only enable coverage on the fastest job
-          - os: "ubuntu-20.04"
-            python-version: "3.8" # Eli (11/12/20): pylint doesn't yet support Python 3.9, so can't run pre-commit yet
+          - os: "ubuntu-latest"
+            python-version: "3.9"
             IS_FASTEST_JOB: true
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,19 +19,17 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-18.04"
-          - "ubuntu-20.04"
-          - "windows-2019"
-          - "macos-10.15"
-          # - "macos-11.0"
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-latest"
         python-version:
             - 3.7
             - 3.8
             - 3.9
         include:
           # only enable coverage on the fastest job
-          - os: "ubuntu-20.04"
-            python-version: "3.8" # Eli (11/12/20): pylint doesn't yet support Python 3.9, so can't run pre-commit yet
+          - os: "ubuntu-latest"
+            python-version: "3.9"
             IS_FASTEST_JOB: true
 
     name: Test code before publishing in Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -170,7 +168,7 @@ jobs:
       fail-fast: false
       matrix: # if publishing pure python code, then disable all except one os and python version combination. But if publishing code that uses Cython then likely all combinations will be needed
         os:
-          - "ubuntu-20.04"
+          - "ubuntu-latest"
         python-version:
             - 3.9
     name: Publish to Test PyPI for Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -234,11 +232,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-18.04"
-          - "ubuntu-20.04"
-          - "windows-2019"
-          - "macos-10.15"
-          # - "macos-11.0"
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-latest"
         python-version:
             - 3.7
             - 3.8
@@ -314,7 +310,7 @@ jobs:
       fail-fast: false
       matrix: # if publishing pure python code, then disable all except one os and python version combination. But if publishing code that uses Cython then likely all combinations will be needed
         os:
-          - "ubuntu-20.04"
+          - "ubuntu-latest"
         python-version:
             - 3.9
     name: Publish to PyPI for Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -379,11 +375,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-18.04"
-          - "ubuntu-20.04"
-          - "windows-2019"
-          - "macos-10.15"
-          # - "macos-11.0"
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-latest"
         python-version:
             - 3.7
             - 3.8
@@ -459,7 +453,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-20.04"
+          - "ubuntu-latest"
     name: Creating tag on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # IDE
+.vscode/
 .idea/
 .~c9*
 
@@ -12,8 +13,8 @@
 __pycache__/
 
 # Venv
-.venv/
-venv/
+.venv*/
+venv*/
 *.egg-info
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     -   id: fix-encoding-pragma
 
 -   repo: https://github.com/psf/black
-    rev: '20.8b1'  # pick a git hash / tag to point to
+    rev: '23.10.0'  # pick a git hash / tag to point to
     hooks:
     -   id: black
 
@@ -45,7 +45,7 @@ repos:
 
 # Safety/Security Issues
 -   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.1.3
+    rev: v1.3.2
     hooks:
     -   id: python-safety-dependencies-check
 
@@ -108,12 +108,18 @@ repos:
         exclude: prerelease.py
 
 -   repo: https://github.com/NanoSurface-Biomedical/pre-commit-pylint
-    rev: "5a76725fa664ca733db485598da5c8460cf3347f" # pick a git hash / tag to point to
+    rev: 5a76725fa664ca733db485598da5c8460cf3347f # pick a git hash / tag to point to
+    hooks:
+    -   id: python-check-no-print-statments
+
+-   repo: local
     hooks:
     -   id: pylint-pass-with-displayed-warnings
         name: pylint-src
+        entry: pylint
+        language: system
         args:
-        - --codes-to-allow=W0511
+        - --enable=W0511
         - src
         - --rcfile=src/pylintrc
         - --ignore-patterns=.*~.*
@@ -122,13 +128,13 @@ repos:
         verbose: true
     -   id: pylint-pass-with-displayed-warnings
         name: pylint-tests
+        entry: pylint
+        language: system
         args:
-        - --codes-to-allow=W0511
+        - --enable=W0511
         - tests
         - --rcfile=tests/pylintrc
         - --ignore-patterns=.*~.*
         files: 'tests/.*\.py$'
         exclude: ('.*\~.*')|(prerelease.py)
         verbose: true
-    -   id: python-check-no-print-statments
-        exclude: prerelease.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-sphinx==3.5.3
+sphinx==5.3.0  # latest with python 3.7 support

--- a/prerelease.py
+++ b/prerelease.py
@@ -59,10 +59,10 @@ class Prereleaser(baserelease.Basereleaser):
         self._grab_history()
         if self.data["update_history"]:
             # Print changelog for this release.
-            print(
-                "Changelog entries for version {0}:\n".format(self.data["new_version"])
+            print(  # allow-print
+                f"Changelog entries for version {self.data['new_version']}:\n"
             )
-            print(self.data.get("history_last_release"))
+            print(self.data.get("history_last_release"))  # allow-print
         # Grab and set new version.
         self._grab_version()
         if self.data["update_history"]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pre-commit==2.12.0 # run 'pre-commit install' initially to install the git hooks
 pytest==6.2.3
 pytest-cov==2.11.1
 pytest-randomly==3.6.0
-pylint==2.7.4
+pylint==2.13.0
 pytest-pylint==0.18.0
 zest.releaser[recommended]==6.22.1
 misc_test_utils==0.2

--- a/src/labware_domain_models/barcoded_sbs_labware.py
+++ b/src/labware_domain_models/barcoded_sbs_labware.py
@@ -59,6 +59,6 @@ class BarcodedSbsLabware(DomainModelWithUuid):
 
         return True
 
-    def __hash__(self) -> int:  # pylint: disable=useless-super-delegation
-        # pylint is wrong. you MUST define the __hash__ function in every class.
+    def __hash__(self) -> int:
+        # pylint is wrong, you MUST define the __hash__ function in every class.
         return int(super().__hash__())

--- a/src/labware_domain_models/exceptions.py
+++ b/src/labware_domain_models/exceptions.py
@@ -15,7 +15,6 @@ class WellCoordinatesRequireA1CenterError(WellCoordinatesGenerationError):
 
 
 class WellCoordinatesRequireRowOffsetError(WellCoordinatesGenerationError):
-
     pass
 
 

--- a/src/labware_domain_models/labware_definitions.py
+++ b/src/labware_domain_models/labware_definitions.py
@@ -148,7 +148,7 @@ class LabwareDefinition(DomainModelWithUuid):
             column: zero-based
             pad_zeros: if set to true, on dense plates (more than 9 columns), a leading zero will be added for any single digit numbers
         """
-        column_str = "%s" % (column + 1)
+        column_str = f"{column + 1}"
         if pad_zeros:
             self.validate_row_and_column_counts()
             if self.column_count is None:
@@ -169,7 +169,7 @@ class LabwareDefinition(DomainModelWithUuid):
         """
         row_char = row_index0_to_letters(row)
         column_str = self._get_formatted_column_string(column, pad_zeros)
-        return "%s%s" % (row_char, column_str)
+        return f"{row_char}{column_str}"
 
     def get_well_index_from_row_and_column(
         self,
@@ -273,7 +273,7 @@ class LabwareDefinition(DomainModelWithUuid):
             return False
         return True
 
-    def __hash__(self) -> int:  # pylint: disable=useless-super-delegation
+    def __hash__(self) -> int:
         # pylint is wrong. you MUST define the __hash__ function in every class.
         return int(super().__hash__())
 

--- a/src/pylintrc
+++ b/src/pylintrc
@@ -40,7 +40,7 @@ confidence=
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time. See also the "--disable" option for examples.
-enable=use-symbolic-message-instead,useless-supression,fixme
+enable=use-symbolic-message-instead,useless-suppression,fixme
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -40,7 +40,7 @@ confidence=
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time. See also the "--disable" option for examples.
-enable=use-symbolic-message-instead,useless-supression,fixme
+enable=use-symbolic-message-instead,useless-suppression,fixme
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
@@ -54,7 +54,7 @@ enable=use-symbolic-message-instead,useless-supression,fixme
 
 disable=
     #attribute-defined-outside-init,
-    #duplicate-code,
+    duplicate-code,
     # tests can be named longer and more descriptively than normal functions
     invalid-name,
     # pylint struggles to understand fixtures in test function arguments

--- a/tests/test_labware_definitions.py
+++ b/tests/test_labware_definitions.py
@@ -566,7 +566,7 @@ def test_LabwareDefinition__get_xy_coordinates_of_well(
     test_description,
 ):
     labware_definition = LabwareDefinition(**labware_definition_kwargs)
-    kwargs: Dict[str, Any] = dict()
+    kwargs: Dict[str, Any] = {}
     if x_offset is not None:
         kwargs["x_offset"] = x_offset
     if y_offset is not None:


### PR DESCRIPTION
Avoiding problems with pre-commit running (at all) in python3.8
-----------------------------------------------------------------------

- Upgrade _black_ to latest (working). Side effect is a minor reformat of _exceptions.py_
- Upgrade _safety_ to latest. Side effect is a reported security issue with _pylint_, which is upgraded to 2.17.7
- Upgrade _pylint hook_. Latest guidance is to use a [local hook](https://pylint.pycqa.org/en/latest/user_guide/installation/pre-commit-integration.html). I had to chase this around, update a couple of rules and the code.


Locally this is now running for me with both 3.8 and 3.9